### PR TITLE
Refact MPTCP support by setsocketoption

### DIFF
--- a/src/java.base/share/classes/java/net/ServerSocket.java
+++ b/src/java.base/share/classes/java/net/ServerSocket.java
@@ -107,7 +107,7 @@ public class ServerSocket implements java.io.Closeable {
      * @throws    IOException IO error when opening the socket.
      */
     public ServerSocket() throws IOException {
-        this.impl = createImpl();
+        this.impl = createImpl(false);
     }
 
     /**
@@ -212,12 +212,52 @@ public class ServerSocket implements java.io.Closeable {
      */
     @SuppressWarnings("this-escape")
     public ServerSocket(int port, int backlog, InetAddress bindAddr) throws IOException {
+        this(port, backlog, bindAddr, false);
+    }
+
+    /**
+     * Create a server using <i>mptcp</i> (Multipath TCP) or TCP protocol with
+     * the specified port, listen backlog, and local IP address to bind to.
+     * The <i>bindAddr</i> argument can be used on a multi-homed host for a
+     * ServerSocket that will only accept connect requests to one of its addresses.
+     * If <i>bindAddr</i> is null, it will default accepting
+     * connections on any/all local addresses.
+     * The port must be between 0 and 65535, inclusive.
+     * A port number of {@code 0} means that the port number is
+     * automatically allocated, typically from an ephemeral port range.
+     * This port number can then be retrieved by calling
+     * {@link #getLocalPort getLocalPort}.
+     *
+     * The {@code backlog} argument is the requested maximum number of
+     * pending connections on the socket. Its exact semantics are implementation
+     * specific. In particular, an implementation may impose a maximum length
+     * or may choose to ignore the parameter altogether. The value provided
+     * should be greater than {@code 0}. If it is less than or equal to
+     * {@code 0}, then an implementation specific default will be used.
+     *
+     * The {@code mptcp} argument is used to control whether to create a socket
+     * with MPTCP or TCP protocol.
+     *
+     * @param port  the port number, or {@code 0} to use a port
+     *              number that is automatically allocated.
+     * @param backlog requested maximum length of the queue of incoming
+     *                connections.
+     * @param bindAddr the local InetAddress the server will bind to
+     * @param mptcp create a socket with MPTCP or TCP protocol.
+     *
+     * @throws  IOException if an I/O error occurs when opening the socket.
+     * @throws     IllegalArgumentException if the port parameter is outside
+     *             the specified range of valid port values, which is between
+     *             0 and 65535, inclusive.
+     */
+    @SuppressWarnings("this-escape")
+    public ServerSocket(int port, int backlog, InetAddress bindAddr, boolean mptcp) throws IOException {
         if (port < 0 || port > 0xFFFF)
             throw new IllegalArgumentException("Port value out of range: " + port);
         if (backlog < 1)
             backlog = 50;
 
-        this.impl = createImpl();
+        this.impl = createImpl(mptcp);
         try {
             bind(new InetSocketAddress(bindAddr, port), backlog);
         } catch (IOException e) {
@@ -229,13 +269,15 @@ public class ServerSocket implements java.io.Closeable {
     /**
      * Create a SocketImpl for a server socket. The SocketImpl is created
      * without an underlying socket.
+     *
+     * @param mptcp create a socket with MPTCP or TCP protocol.
      */
-    private static SocketImpl createImpl() {
+    private static SocketImpl createImpl(boolean mptcp) {
         SocketImplFactory factory = ServerSocket.factory;
         if (factory != null) {
             return factory.createSocketImpl();
         } else {
-            return SocketImpl.createPlatformSocketImpl(true);
+            return SocketImpl.createPlatformSocketImpl(true, mptcp);
         }
     }
 
@@ -556,7 +598,7 @@ public class ServerSocket implements java.io.Closeable {
         assert impl instanceof PlatformSocketImpl;
 
         // create a new platform SocketImpl and accept the connection
-        SocketImpl psi = SocketImpl.createPlatformSocketImpl(false);
+        SocketImpl psi = SocketImpl.createPlatformSocketImpl(false, false);
         implAccept(psi);
         return psi;
     }

--- a/src/java.base/share/classes/java/net/Socket.java
+++ b/src/java.base/share/classes/java/net/Socket.java
@@ -168,7 +168,7 @@ public class Socket implements java.io.Closeable {
      * @since   1.1
      */
     public Socket() {
-        this.impl = createImpl();
+        this.impl = createImpl(false);
     }
 
     /**
@@ -207,7 +207,7 @@ public class Socket implements java.io.Closeable {
                 checkAddress (epoint.getAddress(), "Socket");
             }
             // create a SOCKS or HTTP SocketImpl that delegates to a platform SocketImpl
-            SocketImpl delegate = SocketImpl.createPlatformSocketImpl(false);
+            SocketImpl delegate = SocketImpl.createPlatformSocketImpl(false, false);
             impl = (type == Proxy.Type.SOCKS) ? new SocksSocketImpl(p, delegate)
                                               : new HttpConnectSocketImpl(p, delegate, this);
         } else {
@@ -215,7 +215,7 @@ public class Socket implements java.io.Closeable {
                 // create a platform or custom SocketImpl for the DIRECT case
                 SocketImplFactory factory = Socket.factory;
                 if (factory == null) {
-                    impl = SocketImpl.createPlatformSocketImpl(false);
+                    impl = SocketImpl.createPlatformSocketImpl(false, false);
                 } else {
                     impl = factory.createSocketImpl();
                 }
@@ -404,6 +404,39 @@ public class Socket implements java.io.Closeable {
     }
 
     /**
+     * Creates a stream socket and connects it to the specified port
+     * number on the named host using Multipath TCP (MPTCP) or TCP
+     * protocol.
+     * <p>
+     * If the specified host is {@code null} it is the equivalent of
+     * specifying the address as
+     * {@link java.net.InetAddress#getByName InetAddress.getByName}{@code (null)}.
+     * In other words, it is equivalent to specifying an address of the
+     * loopback interface. </p>
+     * <p>
+     * If the application has specified a {@linkplain SocketImplFactory client
+     * socket implementation factory}, that factory's
+     * {@linkplain SocketImplFactory#createSocketImpl() createSocketImpl}
+     * method is called to create the actual socket implementation. Otherwise
+     * a system-default socket implementation is created.
+     *
+     * @param      host     the host name, or {@code null} for the loopback address.
+     * @param      port     the port number.
+     * @param      stream   must be true, false is not allowed.
+     * @param      mptcp    create a socket with MPTCP or TCP protocol.
+     * @throws     IOException  if an I/O error occurs when creating the socket.
+     * @throws     IllegalArgumentException if the stream parameter is {@code false}
+     *             or if the port parameter is outside the specified range of valid
+     *             port values, which is between 0 and 65535, inclusive.
+     */
+    @SuppressWarnings("this-escape")
+    public Socket(String host, int port, boolean stream, boolean mptcp) throws IOException {
+        this(host != null ? new InetSocketAddress(host, port) :
+               new InetSocketAddress(InetAddress.getByName(null), port),
+             (SocketAddress) null, stream, mptcp);
+    }
+
+    /**
      * Creates a socket and connects it to the specified port number at
      * the specified IP address.
      * <p>
@@ -443,6 +476,22 @@ public class Socket implements java.io.Closeable {
     private Socket(SocketAddress address, SocketAddress localAddr, boolean stream)
         throws IOException
     {
+        this(address, localAddr, stream, false);
+    }
+
+    /**
+     * Initialize a new Socket that is connected to the given remote address.
+     * The MPTCP or TCP protocol socket is optionally bound to a local address
+     * before connecting.
+     *
+     * @param address the remote address to connect to
+     * @param localAddr the local address to bind to, can be null
+     * @param stream true for a stream socket, false for a datagram socket
+     * @param mptcp create a socket with MPTCP or TCP protocol
+     */
+    private Socket(SocketAddress address, SocketAddress localAddr, boolean stream, boolean mptcp)
+        throws IOException
+    {
         Objects.requireNonNull(address);
         if (!stream) {
             throw new IllegalArgumentException(
@@ -451,7 +500,7 @@ public class Socket implements java.io.Closeable {
         assert address instanceof InetSocketAddress;
 
         // create the SocketImpl and the underlying socket
-        SocketImpl impl = createImpl();
+        SocketImpl impl = createImpl(mptcp);
         impl.create(stream);
 
         this.impl = impl;
@@ -471,14 +520,16 @@ public class Socket implements java.io.Closeable {
     /**
      * Create a new SocketImpl for a connecting/client socket. The SocketImpl
      * is created without an underlying socket.
+     *
+     * @param mptcp create a socket with MPTCP or TCP protocol.
      */
-    private static SocketImpl createImpl() {
+    private static SocketImpl createImpl(boolean mptcp) {
         SocketImplFactory factory = Socket.factory;
         if (factory != null) {
             return factory.createSocketImpl();
         } else {
             // create a SOCKS SocketImpl that delegates to a platform SocketImpl
-            SocketImpl delegate = SocketImpl.createPlatformSocketImpl(false);
+            SocketImpl delegate = SocketImpl.createPlatformSocketImpl(false, mptcp);
             return new SocksSocketImpl(delegate);
         }
     }
@@ -498,7 +549,7 @@ public class Socket implements java.io.Closeable {
                     }
                     SocketImpl impl = this.impl;
                     if (impl == null) {
-                        this.impl = impl = createImpl();
+                        this.impl = impl = createImpl(false);
                     }
                     try {
                         impl.create(true);

--- a/src/java.base/share/classes/java/net/SocketImpl.java
+++ b/src/java.base/share/classes/java/net/SocketImpl.java
@@ -48,8 +48,8 @@ public abstract class SocketImpl implements SocketOptions {
      * Creates an instance of platform's SocketImpl
      */
     @SuppressWarnings("unchecked")
-    static <S extends SocketImpl & PlatformSocketImpl> S createPlatformSocketImpl(boolean server) {
-        return (S) new NioSocketImpl(server);
+    static <S extends SocketImpl & PlatformSocketImpl> S createPlatformSocketImpl(boolean server, boolean mptcp) {
+        return (S) new NioSocketImpl(server, mptcp);
     }
 
     /**

--- a/src/java.base/share/classes/sun/nio/ch/Mptcp.java
+++ b/src/java.base/share/classes/sun/nio/ch/Mptcp.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package sun.nio.ch;
+
+import sun.nio.ch.Net;
+import java.io.FileDescriptor;
+import jdk.internal.access.SharedSecrets;
+import jdk.internal.access.JavaIOFileDescriptorAccess;
+import jdk.internal.util.OperatingSystem;
+
+/**
+ * This class defines methods for MPTCP sockets.
+ */
+
+public final class Mptcp {
+    private static final boolean isSupported = OperatingSystem.isLinux();
+    private static final JavaIOFileDescriptorAccess fdAccess =
+        SharedSecrets.getJavaIOFileDescriptorAccess();
+
+    private Mptcp() { }
+
+    /**
+     * Enable MPTCP
+     */
+    public static boolean mptcpify(FileDescriptor fd)
+    {
+        if (!isSupported)
+            throw new UnsupportedOperationException("MPTCP not supported");
+        return mptcpify0(fd);
+    }
+
+    private static native boolean mptcpify0(FileDescriptor fd);
+
+    static {
+        jdk.internal.loader.BootLoader.loadLibrary("net");
+    }
+}

--- a/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
@@ -86,6 +86,9 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
     // true if this is a SocketImpl for a ServerSocket
     private final boolean server;
 
+    // true if this is a SocketImpl for a MptcpServerSocket
+    private final boolean mptcp;
+
     // Lock held when reading (also used when accepting or connecting)
     private final ReentrantLock readLock = new ReentrantLock();
 
@@ -128,9 +131,11 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
     /**
      * Creates an instance of this SocketImpl.
      * @param server true if this is a SocketImpl for a ServerSocket
+     * @param mptcp enable MPTCP
      */
-    public NioSocketImpl(boolean server) {
+    public NioSocketImpl(boolean server, boolean mptcp) {
         this.server = server;
+        this.mptcp = mptcp;
     }
 
     /**
@@ -471,6 +476,10 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
                 fd = Net.serverSocket();
             } else {
                 fd = Net.socket();
+            }
+            if (stream && mptcp) {
+                if (!Mptcp.mptcpify(fd))
+                    throw new IOException("mptcpify failed");
             }
             Runnable closer = closerFor(fd);
             this.fd = fd;

--- a/src/java.base/unix/native/libnio/ch/Mptcp.c
+++ b/src/java.base/unix/native/libnio/ch/Mptcp.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <errno.h>
+
+#include "jni.h"
+#include "jni_util.h"
+#include "net_util.h"
+#include "nio_util.h"
+
+JNIEXPORT jboolean JNICALL
+Java_sun_nio_ch_Mptcp_mptcpify0(JNIEnv *env, jclass cl, jobject fdo)
+{
+    int ret = JNI_TRUE;
+#if defined(__linux__) && defined(IPPROTO_MPTCP)
+    int domain, type, protocol;
+    int v6only, reuse;
+    int fd = fdval(env, fdo);
+    socklen_t len;
+    int fdm;
+
+    len = sizeof(domain);
+    if (getsockopt(fd, SOL_SOCKET, SO_DOMAIN, &domain, &len) == -1) {
+        JNU_ThrowByNameWithLastError(env, JNU_JAVANETPKG "mptcpify",
+                                     "getsockopt(SO_DOMAIN)");
+        return JNI_FALSE;
+    }
+
+    if (domain != AF_INET && domain != AF_INET6) {
+        JNU_ThrowByNameWithLastError(env, JNU_JAVANETPKG "mptcpify",
+                                     "unsupported socket domain");
+        return JNI_FALSE;
+    }
+
+    len = sizeof(type);
+    if (getsockopt(fd, SOL_SOCKET, SO_TYPE, &type, &len) == -1) {
+        JNU_ThrowByNameWithLastError(env, JNU_JAVANETPKG "mptcpify",
+                                     "getsockopt(SO_TYPE)");
+        return JNI_FALSE;
+    }
+
+    if (type != SOCK_STREAM) {
+        JNU_ThrowByNameWithLastError(env, JNU_JAVANETPKG "mptcpify",
+                                     "unsupported socket type");
+        return JNI_FALSE;
+    }
+
+    len = sizeof(protocol);
+    if (getsockopt(fd, SOL_SOCKET, SO_PROTOCOL, &protocol, &len) == -1) {
+        JNU_ThrowByNameWithLastError(env, JNU_JAVANETPKG "mptcpify",
+                                     "getsockopt(SO_PROTOCOL)");
+        return JNI_FALSE;
+    }
+
+    if (protocol != 0 && protocol != IPPROTO_TCP) {
+        JNU_ThrowByNameWithLastError(env, JNU_JAVANETPKG "mptcpify",
+                                     "unsupported socket protocol");
+        return JNI_FALSE;
+    }
+
+    fdm = socket(domain, type, IPPROTO_MPTCP);
+    if (fdm < 0) {
+        JNU_ThrowByNameWithLastError(env, JNU_JAVANETPKG "mptcpify",
+                                     "socket(MPTCP)");
+        return JNI_FALSE;
+    }
+
+    if (domain == AF_INET6 && ipv4_available()) {
+        len = sizeof(v6only);
+        if (getsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, (char*)&v6only, &len) == 0)
+            setsockopt(fdm, IPPROTO_IPV6, IPV6_V6ONLY, (char*)&v6only, len);
+    }
+
+    len = sizeof(reuse);
+    if (getsockopt(fd, SOL_SOCKET, SO_REUSEPORT, (char*)&reuse, &len) == 0)
+        setsockopt(fdm, SOL_SOCKET, SO_REUSEPORT, (char*)&reuse, len);
+
+    if (dup2(fdm, fd) < 0) {
+        ret = JNI_FALSE;
+        JNU_ThrowByNameWithLastError(env, JNU_JAVANETPKG "mptcpify",
+                                     "dup2");
+    }
+
+    if (close(fdm) < 0) {
+        ret = JNI_FALSE;
+        JNU_ThrowByNameWithLastError(env, JNU_JAVANETPKG "mptcpify",
+                                     "close");
+    }
+#endif
+
+    return ret;
+}

--- a/src/jdk.net/linux/classes/jdk/net/LinuxSocketOptions.java
+++ b/src/jdk.net/linux/classes/jdk/net/LinuxSocketOptions.java
@@ -125,6 +125,25 @@ class LinuxSocketOptions extends PlatformSocketOptions {
         return new UnixDomainPrincipal(user, group);
     }
 
+    @Override
+    boolean mptcpSupported() {
+        try {
+            return isMptcpSupported0();
+        } catch (UnsatisfiedLinkError e) {
+           return false;
+        }
+    }
+
+    @Override
+    void setMptcpEnabled(int fd, boolean on) throws SocketException {
+        setMptcpEnabled0(fd, on);
+    }
+
+    @Override
+    boolean getMptcpEnabled(int fd) throws SocketException {
+        return getMptcpEnabled0(fd);
+    }
+
     private static native void setTcpKeepAliveProbes0(int fd, int value) throws SocketException;
     private static native void setTcpKeepAliveTime0(int fd, int value) throws SocketException;
     private static native void setTcpKeepAliveIntvl0(int fd, int value) throws SocketException;
@@ -140,6 +159,9 @@ class LinuxSocketOptions extends PlatformSocketOptions {
     private static native boolean quickAckSupported0();
     private static native boolean incomingNapiIdSupported0();
     private static native int getIncomingNapiId0(int fd) throws SocketException;
+    private static native boolean isMptcpSupported0();
+    private static native void setMptcpEnabled0(int fd, boolean on) throws SocketException;
+    private static native boolean getMptcpEnabled0(int fd) throws SocketException;
     static {
         System.loadLibrary("extnet");
     }

--- a/src/jdk.net/linux/native/libextnet/LinuxSocketOptions.c
+++ b/src/jdk.net/linux/native/libextnet/LinuxSocketOptions.c
@@ -29,6 +29,11 @@
 #include <errno.h>
 #include <unistd.h>
 
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <sys/types.h>
+
 #include <jni.h>
 #include <netinet/tcp.h>
 #include <netinet/in.h>
@@ -289,4 +294,133 @@ JNIEXPORT jboolean JNICALL Java_jdk_net_LinuxSocketOptions_getIpDontFragment0
     rv = getsockopt(fd, optlevel, optname, &optval, &sz);
     handleError(env, rv, "get option IP_DONTFRAGMENT failed");
     return optval == IP_PMTUDISC_DO ? JNI_TRUE : JNI_FALSE;
+}
+
+#ifndef SO_PROTOCOL
+#define SO_PROTOCOL 38
+#endif
+
+static int read_int_file(const char* path, int* out) {
+    char buf[32];
+    int fd = open(path, O_RDONLY | O_CLOEXEC);
+    if (fd < 0) return -1;
+    ssize_t n = read(fd, buf, sizeof(buf) - 1);
+    close(fd);
+    if (n <= 0) return -1;
+    buf[n] = '\0';
+    *out = atoi(buf);
+    return 0;
+}
+
+/* Class:     jdk_net_LinuxSocketOptions
+ * Method:    isMptcpSupported0
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_jdk_net_LinuxSocketOptions_isMptcpSupported0
+(JNIEnv *env, jclass clazz) {
+    int v;
+    if (read_int_file("/proc/sys/net/mptcp/enabled", &v) == 0) {
+        return JNI_TRUE;
+    }
+
+    return JNI_FALSE;
+}
+
+/*
+ * Class:    jdk_net_LinuxSocketOptions
+ * Method:   setMptcpEnabled0
+ * Signature: (II)V
+ */
+JNIEXPORT void JNICALL
+Java_jdk_net_LinuxSocketOptions_setMptcpEnabled0(JNIEnv *env, jclass clazz,
+                                                 jint fd, jboolean on) {
+#ifdef IPPROTO_MPTCP
+    if (!on) return;
+
+    int domain, type, proto;
+    int v6only, reuse;
+    socklen_t len = sizeof(int);
+
+    if (getsockopt(fd, SOL_SOCKET, SO_DOMAIN, &domain, &len) == -1) {
+        JNU_ThrowByNameWithLastError(env, "java/net/SocketException", "getsockopt(SO_DOMAIN) failed");
+        return;
+    }
+
+    if (domain != AF_INET && domain != AF_INET6) {
+        JNU_ThrowByName(env, "java/net/SocketException", "unsupported socket domain");
+        return;
+    }
+
+    if (getsockopt(fd, SOL_SOCKET, SO_TYPE, &type, &len) == -1) {
+        JNU_ThrowByNameWithLastError(env, "java/net/SocketException", "getsockopt(SO_TYPE) failed");
+        return;
+    }
+
+    if (type != SOCK_STREAM) {
+        JNU_ThrowByName(env, "java/net/SocketException", "unsupported socket type");
+        return;
+    }
+
+    if (getsockopt(fd, SOL_SOCKET, SO_PROTOCOL, &proto, &len) == -1) {
+        JNU_ThrowByNameWithLastError(env, "java/net/SocketException", "getsockopt(SO_PROTOCOL) failed");
+        return;
+    }
+
+    if (proto !=0 && proto != IPPROTO_TCP) {
+        JNU_ThrowByName(env, "java/net/SocketException", "unsupported socket protocol");
+        return;
+    }
+
+    int fdm = socket(domain, type, IPPROTO_MPTCP);
+    if (fdm < 0) {
+        JNU_ThrowByNameWithLastError(env, "java/net/SocketException", "socket(IPPROTO_MPTCP) failed");
+        return;
+    }
+
+    if (domain == AF_INET6) {
+        if (getsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, &len) == 0) {
+            setsockopt(fdm, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, len);
+        }
+    }
+
+    if (getsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &reuse, &len) == 0) {
+        setsockopt(fdm, SOL_SOCKET, SO_REUSEPORT, &reuse, len);
+    }
+
+    if (dup2(fdm, fd) < 0) {
+        JNU_ThrowByNameWithLastError(env, "java/net/SocketException", "dup2 failed");
+        close(fdm);
+        return;
+    }
+    if (close(fdm) < 0) {
+        JNU_ThrowByNameWithLastError(env, "java/net/SocketException", "close failed");
+        return;
+    }
+#else
+    JNU_ThrowByName(env, "java/net/SocketException", "MPTCP not supported on this platform");
+#endif
+}
+
+/*
+ * Class:    jdk_net_LinuxSocketOptions
+ * Method:   getMptcpEnabled0
+ * Signature: (I)I
+ */
+JNIEXPORT jboolean JNICALL
+Java_jdk_net_LinuxSocketOptions_getMptcpEnabled0(JNIEnv *env, jclass clazz, jint fd) {
+#ifdef SO_PROTOCOL
+    int proto = 0;
+    socklen_t len = sizeof(int);
+    if (getsockopt(fd, SOL_SOCKET, SO_PROTOCOL, &proto, &len) == -1) {
+        JNU_ThrowByNameWithLastError(env, "java/net/SocketException", "getsockopt(SO_PROTOCOL) failed");
+        return JNI_FALSE;
+    }
+#ifdef IPPROTO_MPTCP
+    return (proto == IPPROTO_MPTCP) ? JNI_TRUE : JNI_FALSE;
+#else
+    return JNI_FALSE;
+#endif
+#else
+    return JNI_FALSE;
+#endif
 }

--- a/src/jdk.net/share/classes/jdk/net/ExtendedSocketOptions.java
+++ b/src/jdk.net/share/classes/jdk/net/ExtendedSocketOptions.java
@@ -226,6 +226,16 @@ public final class ExtendedSocketOptions {
     public static final SocketOption<Boolean> IP_DONTFRAGMENT =
         new ExtSocketOption<Boolean>("IP_DONTFRAGMENT", Boolean.class);
 
+    /**
+     * Enable Multipath TCP (MPTCP) for stream sockets.
+     *
+     * <p> Must be set before connect()/bind(), exposed only when the platform support.
+     *
+     * @since 26
+     */
+    public static final SocketOption<Boolean> MPTCP_ENABLED =
+        new ExtSocketOption<Boolean>("MPTCP_ENABLED", Boolean.class);
+
     private static final PlatformSocketOptions platformSocketOptions =
             PlatformSocketOptions.get();
 
@@ -239,6 +249,8 @@ public final class ExtendedSocketOptions {
             platformSocketOptions.incomingNapiIdSupported();
     private static final boolean ipDontFragmentSupported  =
             platformSocketOptions.ipDontFragmentSupported();
+    private static final boolean mptcpSupported =
+            platformSocketOptions.mptcpSupported();
 
     private static final Set<SocketOption<?>> extendedOptions = options();
 
@@ -259,6 +271,9 @@ public final class ExtendedSocketOptions {
         if (ipDontFragmentSupported) {
             options.add(IP_DONTFRAGMENT);
         }
+	    if (mptcpSupported) {
+            options.add(MPTCP_ENABLED);
+	    }
         return Collections.unmodifiableSet(options);
     }
 
@@ -286,6 +301,8 @@ public final class ExtendedSocketOptions {
                     setTcpKeepAliveTime(fd, (Integer) value);
                 } else if (option == TCP_KEEPINTERVAL) {
                     setTcpKeepAliveIntvl(fd, (Integer) value);
+                } else if (option == MPTCP_ENABLED) {
+                    setMptcpEnabled(fd, (Boolean) value);
                 } else if (option == SO_INCOMING_NAPI_ID) {
                     if (!incomingNapiIdOptSupported)
                         throw new UnsupportedOperationException("Attempt to set unsupported option " + option);
@@ -316,6 +333,8 @@ public final class ExtendedSocketOptions {
                     return getTcpKeepAliveTime(fd);
                 } else if (option == TCP_KEEPINTERVAL) {
                     return getTcpKeepAliveIntvl(fd);
+                } else if (option == MPTCP_ENABLED) {
+                    return getMptcpEnabled(fd);
                 } else if (option == SO_PEERCRED) {
                     return getSoPeerCred(fd);
                 } else if (option == SO_INCOMING_NAPI_ID) {
@@ -383,6 +402,14 @@ public final class ExtendedSocketOptions {
 
     private static int getIncomingNapiId(FileDescriptor fd) throws SocketException {
         return platformSocketOptions.getIncomingNapiId(fdAccess.get(fd));
+    }
+
+    private static void setMptcpEnabled(FileDescriptor fd, boolean on) throws SocketException {
+        platformSocketOptions.setMptcpEnabled(fdAccess.get(fd), on);
+    }
+
+    private static boolean getMptcpEnabled(FileDescriptor fd) throws SocketException {
+        return platformSocketOptions.getMptcpEnabled(fdAccess.get(fd));
     }
 
     static class PlatformSocketOptions {
@@ -482,6 +509,18 @@ public final class ExtendedSocketOptions {
 
         int getIncomingNapiId(int fd) throws SocketException {
             throw new UnsupportedOperationException("unsupported SO_INCOMING_NAPI_ID socket option");
+        }
+
+        boolean mptcpSupported() {
+            return false;
+        }
+
+        void setMptcpEnabled(int fd, boolean on) throws SocketException {
+            throw new UnsupportedOperationException("unsupported MPTCP option");
+        }
+
+        boolean getMptcpEnabled(int fd) throws SocketException {
+            return false;
         }
     }
 }

--- a/test/jdk/java/net/ServerSocket/TestMPTCP.java
+++ b/test/jdk/java/net/ServerSocket/TestMPTCP.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @summary ServerSocket(mptcp=true) creation semantics with MPTCP enabled/disabled
+ * @requires os.family == "linux"
+ * @run main/othervm TestMPTCP
+ */
+
+import java.io.IOException;
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+public class TestMPTCP {
+
+    public static void main(String[] args) throws Exception {
+        final boolean enabled = kernelEnabled();
+        final InetAddress loop = InetAddress.getLoopbackAddress();
+
+        if(!enabled) {
+            // Negative path: disabled => creation should fail.
+            try (ServerSocket s = new ServerSocket(0, 50, loop, true)) {
+                throw new AssertionError("Expected failure, but ServerSocket created");
+            } catch (IOException expected) {
+                System.out.println("[OK] MPTCP disabled: creation failed as expected: " + expected);
+            }
+            return;
+        }
+
+        // Positive path: enabled => can create and accept once.
+        try (ServerSocket srv = new ServerSocket(0, 50, loop, true)) {
+            final int port = srv.getLocalPort();
+
+            Thread client = new Thread(() -> {
+                try (Socket c = new Socket(loop.getHostAddress(), port, true, true)) {
+                    c.setSoTimeout(10_000);
+                    c.getOutputStream().write(new byte[]{'h','e','l','l','o'});
+                    c.getOutputStream().flush();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            client.start();
+
+            try (Socket cli = srv.accept()) {
+                cli.setSoTimeout(10_000);
+                byte[] buf = cli.getInputStream().readNBytes(5);
+                if (!"hello".equals(new String(buf))) {
+                    throw new AssertionError("Echo mismatch");
+		}
+            }
+
+            client.join(10_000);
+            if(client.isAlive()) {
+                throw new AssertionError("Client thread did not finish in time");
+            }
+        }
+    }
+
+    // Linux after 5.6: /proc/sys/net/mptcp/enabled
+    private static boolean kernelEnabled() {
+        Integer v = readInt("/proc/sys/net/mptcp/enabled");
+        if (v == null) v = readInt("/proc/sys/net/mptcp/mptcp_enabled");
+        return v != null && v == 1;
+    }
+
+    private static Integer readInt(String path) {
+        try (BufferedReader r = new BufferedReader(new FileReader(path))) {
+            return Integer.parseInt(r.readLine().trim());
+        } catch (Throwable ignore) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
jdk.net: Add MPTCP_ENABLED as an extended socket option (delegate to original sun.nio.ch.Mptcp design).

This change exposes a minimal, linux-only MPTCP option through the setOption/getOption entry points.
It reuse the backend from the previous PRs(sun.nio.ch.Mptcp + native mptcpifio) instead of duplicating JNI in libextnet.

Notes:
1. Must be called before bind()/connect().
2. Fall back if doesn' t support MPTCP.
3. Implement getOption(MPPTCP_ENABLED) return the current FD protocol.

Sample:
Run sample as:
ss.setOption(ExtendedSocketOptions.MPTCP_ENABLED, true);
ss.bind(new InetSocketAddress("127.0.0.1", port));wq

Suggested-by: Alan Bateman <alan.bateman@oracle.com>
Co-developed-by: Gang Yan <yangang@kylinos.cn>
Signed-off-by: Gang Yan <yangang@kylinos.cn>
Co-developed-by: Xiang Gao <gaoxiang@kylinos.cn>
Signed-off-by: Xiang Gao <gaoxiang@kylinos.cn>
Signed-off-by: Geliang Tang <geliang@kernel.org>